### PR TITLE
Gulpconfig no longer targets all config.php. 

### DIFF
--- a/app/templates/gulpconfig.json
+++ b/app/templates/gulpconfig.json
@@ -50,7 +50,7 @@
 			"assets/files",
 			"assets/logs",
 			"assets/sessions",
-			"config.php",
+			"src/site/config.php",
 			"robots.txt"
 		]
 	},


### PR DESCRIPTION
This fixes an issue when updating processwire locally as the wire/config.php is also ignored.